### PR TITLE
Check explicitly for version 1.7

### DIFF
--- a/product_test.go
+++ b/product_test.go
@@ -89,7 +89,7 @@ func TestProductListWithPagination(t *testing.T) {
 
 	// The strconv.Atoi error changed in go 1.8, 1.7 is still being tested/supported.
 	limitConversionErrorMessage := `strconv.Atoi: parsing "invalid": invalid syntax`
-	if runtime.Version() < "go1.8" {
+	if runtime.Version()[2:5] == "1.7" {
 		limitConversionErrorMessage = `strconv.ParseInt: parsing "invalid": invalid syntax`
 	}
 


### PR DESCRIPTION
@epelc Sorry, previous implementation would also match 1.10+ so I've changed it to be a hard check on 1.7. 
This would obviously also match 1.70+ but just wanted to keep the implementation as simple as possible and as you mentioned hopefully 1.7 is dropped soon.